### PR TITLE
Clarify optionality

### DIFF
--- a/ruby/ruby-agreement.html
+++ b/ruby/ruby-agreement.html
@@ -18,7 +18,7 @@ dfn {
 <h1>Agreement on HTML Ruby Markup</h1>
 
 <p>
-The W3C MAY specify extended HTML Ruby markup
+The W3C can specify extended HTML Ruby markup
 (based on <a href="https://github.com/whatwg/html/pull/6478">PR#6478</a>)
 under the <a href="https://www.w3.org/Consortium/Process/#rec-track">REC track</a>.
 This will be a derived document with some textual copying from <a href="https://html.spec.whatwg.org/multipage/">WHATWG HTML</a>
@@ -26,12 +26,12 @@ and <a href="https://www.w3.org/TR/2014/NOTE-html-ruby-extensions-20140204/">W3C
 but the W3C and WHATWG mutually agree that publishing it is within the bounds of our <a href="https://www.w3.org/2019/04/WHATWG-W3C-MOU">MoU</a>.
 
 <p>
-W3C editors MAY offer pull requests to keep the HTML spec in sync,
+W3C editors can offer pull requests to keep the HTML spec in sync,
 both technically and editorially,
 for the subset of features defined in both specs,
 so that readers of both specs can benefit from any improvements.
 Once the <a href="https://whatwg.org/working-mode#additions">criteria for addition</a> to WHATWG Living Standards are met,
-W3C editors MAY also offer pull requests to fully integrate the extended ruby markup definitions
+W3C editors can also offer pull requests to fully integrate the extended ruby markup definitions
 into WHATWG HTML.
 WHATWG HTML editors will review these contributions in good faith,
 and merge those they deem acceptable
@@ -40,19 +40,3 @@ under the WHATWG <a href="https://whatwg.org/working-mode">working mode</a>.
 <p>
 The <abbr title="Status Of This Document">SOTD</abbr> section of the W3C Ruby Extension spec
 will link to this agreement.
-
-<h2>Specialized Terms</h2>
-
-<p>
-The term MAY
-is used in accordance with [RFC2119].
-
-<dl>
-	<dt><dfn>[RFC2119]</dfn>
-	<dd>
-		S. Bradner.
-		<a href="https://datatracker.ietf.org/doc/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>.
-		March 1997.
-		Best Current Practice.
-		URL: <a href="https://datatracker.ietf.org/doc/html/rfc2119">https://datatracker.ietf.org/doc/html/rfc2119</a>
-</dl>

--- a/ruby/ruby-agreement.html
+++ b/ruby/ruby-agreement.html
@@ -9,12 +9,16 @@ body {
 	margin: auto;
 	font-family: sans-serif;
 }
+dfn {
+	font-style: normal;
+	font-weight: bold;
+}
 </style>
 
 <h1>Agreement on HTML Ruby Markup</h1>
 
 <p>
-The W3C will specify extended HTML Ruby markup
+The W3C MAY specify extended HTML Ruby markup
 (based on <a href="https://github.com/whatwg/html/pull/6478">PR#6478</a>)
 under the <a href="https://www.w3.org/Consortium/Process/#rec-track">REC track</a>.
 This will be a derived document with some textual copying from <a href="https://html.spec.whatwg.org/multipage/">WHATWG HTML</a>
@@ -22,12 +26,12 @@ and <a href="https://www.w3.org/TR/2014/NOTE-html-ruby-extensions-20140204/">W3C
 but the W3C and WHATWG mutually agree that publishing it is within the bounds of our <a href="https://www.w3.org/2019/04/WHATWG-W3C-MOU">MoU</a>.
 
 <p>
-W3C editors may offer pull requests to keep the HTML spec in sync,
+W3C editors MAY offer pull requests to keep the HTML spec in sync,
 both technically and editorially,
 for the subset of features defined in both specs,
 so that readers of both specs can benefit from any improvements.
 Once the <a href="https://whatwg.org/working-mode#additions">criteria for addition</a> to WHATWG Living Standards are met,
-W3C editors may also offer pull requests to fully integrate the extended ruby markup definitions
+W3C editors MAY also offer pull requests to fully integrate the extended ruby markup definitions
 into WHATWG HTML.
 WHATWG HTML editors will review these contributions in good faith,
 and merge those they deem acceptable
@@ -36,3 +40,19 @@ under the WHATWG <a href="https://whatwg.org/working-mode">working mode</a>.
 <p>
 The <abbr title="Status Of This Document">SOTD</abbr> section of the W3C Ruby Extension spec
 will link to this agreement.
+
+<h2>Specialized Terms</h2>
+
+<p>
+The term MAY
+is used in accordance with [RFC2119].
+
+<dl>
+	<dt><dfn>[RFC2119]</dfn>
+	<dd>
+		S. Bradner.
+		<a href="https://datatracker.ietf.org/doc/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>.
+		March 1997.
+		Best Current Practice.
+		URL: <a href="https://datatracker.ietf.org/doc/html/rfc2119">https://datatracker.ietf.org/doc/html/rfc2119</a>
+</dl>


### PR DESCRIPTION
Explicitly use RFC2119 “MAY” when referring to things that are optional, and link to RFC2119 for clarity.

In response to https://github.com/w3c/whatwg-coord/pull/14#discussion_r807326539 and https://github.com/w3c/whatwg-coord/pull/14#discussion_r808521431